### PR TITLE
fix: Tree package bug (#589)

### DIFF
--- a/structure/tree/avl.go
+++ b/structure/tree/avl.go
@@ -1,3 +1,9 @@
+// AVL tree is a self-balancing binary search tree.
+//
+// For more details check out those link below here:
+// Wikipedia article: https://en.wikipedia.org/wiki/AVL_tree
+// see avl.go
+
 package tree
 
 import (
@@ -5,18 +11,56 @@ import (
 	"github.com/TheAlgorithms/Go/math/max"
 )
 
-type AVL[T constraints.Ordered] struct {
-	*binaryTree[T]
+// Verify Interface Compliance
+var _ Node[int] = &AVLNode[int]{}
+
+// AVLNode represents a single node in the AVL.
+type AVLNode[T constraints.Ordered] struct {
+	key    T
+	parent *AVLNode[T]
+	left   *AVLNode[T]
+	right  *AVLNode[T]
+	height int
 }
 
-// NewAVL create a novel AVL tree
+func (n *AVLNode[T]) Key() T {
+	return n.key
+}
+
+func (n *AVLNode[T]) Parent() Node[T] {
+	return n.parent
+}
+
+func (n *AVLNode[T]) Left() Node[T] {
+	return n.left
+}
+
+func (n *AVLNode[T]) Right() Node[T] {
+	return n.right
+}
+
+func (n *AVLNode[T]) Height() int {
+	return n.height
+}
+
+// AVL represents a AVL tree.
+// By default, _NIL = nil.
+type AVL[T constraints.Ordered] struct {
+	Root *AVLNode[T]
+	_NIL *AVLNode[T] // a sentinel value for nil
+}
+
+// NewAVL creates a novel AVL tree
 func NewAVL[T constraints.Ordered]() *AVL[T] {
 	return &AVL[T]{
-		binaryTree: &binaryTree[T]{
-			Root: nil,
-			NIL:  nil,
-		},
+		Root: nil,
+		_NIL: nil,
 	}
+}
+
+// Empty determines the AVL tree is empty
+func (avl *AVL[T]) Empty() bool {
+	return avl.Root == avl._NIL
 }
 
 // Push a chain of Node's into the AVL Tree
@@ -36,42 +80,140 @@ func (avl *AVL[T]) Delete(key T) bool {
 	return true
 }
 
-func (avl *AVL[T]) pushHelper(root *Node[T], key T) *Node[T] {
-	if root == nil {
-		return &Node[T]{
-			Key:    key,
-			Height: 1,
+// Get a Node from the AVL Tree
+func (avl *AVL[T]) Get(key T) (Node[T], bool) {
+	return searchTreeHelper[T](avl.Root, avl._NIL, key)
+}
+
+// Has Determines the tree has the node of Key
+func (avl *AVL[T]) Has(key T) bool {
+	_, ok := searchTreeHelper[T](avl.Root, avl._NIL, key)
+	return ok
+}
+
+// PreOrder Traverses the tree in the following order Root --> Left --> Right
+func (avl *AVL[T]) PreOrder() []T {
+	traversal := make([]T, 0)
+	preOrderRecursive[T](avl.Root, avl._NIL, &traversal)
+	return traversal
+}
+
+// InOrder Traverses the tree in the following order Left --> Root --> Right
+func (avl *AVL[T]) InOrder() []T {
+	return inOrderHelper[T](avl.Root, avl._NIL)
+}
+
+// PostOrder traverses the tree in the following order Left --> Right --> Root
+func (avl *AVL[T]) PostOrder() []T {
+	traversal := make([]T, 0)
+	postOrderRecursive[T](avl.Root, avl._NIL, &traversal)
+	return traversal
+}
+
+// LevelOrder returns the level order traversal of the tree
+func (avl *AVL[T]) LevelOrder() []T {
+	traversal := make([]T, 0)
+	levelOrderHelper[T](avl.Root, avl._NIL, &traversal)
+	return traversal
+}
+
+// AccessNodesByLayer accesses nodes layer by layer (2-D array),  instead of printing the results as 1-D array.
+func (avl *AVL[T]) AccessNodesByLayer() [][]T {
+	return accessNodeByLayerHelper[T](avl.Root, avl._NIL)
+}
+
+// Depth returns the calculated depth of the AVL tree
+func (avl *AVL[T]) Depth() int {
+	return calculateDepth[T](avl.Root, avl._NIL, 0)
+}
+
+// Max returns the Max value of the tree
+func (avl *AVL[T]) Max() (T, bool) {
+	ret := maximum[T](avl.Root, avl._NIL)
+	if ret == avl._NIL {
+		var dft T
+		return dft, false
+	}
+	return ret.Key(), true
+}
+
+// Min returns the Min value of the tree
+func (avl *AVL[T]) Min() (T, bool) {
+	ret := minimum[T](avl.Root, avl._NIL)
+	if ret == avl._NIL {
+		var dft T
+		return dft, false
+	}
+	return ret.Key(), true
+}
+
+// Predecessor returns the Predecessor of the node of Key
+// if there is no predecessor, return default value of type T and false
+// otherwise return the Key of predecessor and true
+func (avl *AVL[T]) Predecessor(key T) (T, bool) {
+	node, ok := searchTreeHelper[T](avl.Root, avl._NIL, key)
+	if !ok {
+		var dft T
+		return dft, ok
+	}
+	return predecessorHelper[T](node, avl._NIL)
+}
+
+// Successor returns the Successor of the node of Key
+// if there is no successor, return default value of type T and false
+// otherwise return the Key of successor and true
+func (avl *AVL[T]) Successor(key T) (T, bool) {
+	node, ok := searchTreeHelper[T](avl.Root, avl._NIL, key)
+	if !ok {
+		var dft T
+		return dft, ok
+	}
+	return successorHelper[T](node, avl._NIL)
+}
+
+func (avl *AVL[T]) pushHelper(root *AVLNode[T], key T) *AVLNode[T] {
+	if root == avl._NIL {
+		return &AVLNode[T]{
+			key:    key,
+			left:   avl._NIL,
+			right:  avl._NIL,
+			parent: avl._NIL,
+			height: 1,
 		}
 	}
 
 	switch {
-	case key < root.Key:
-		root.Left = avl.pushHelper(root.Left, key)
-	case key > root.Key:
-		root.Right = avl.pushHelper(root.Right, key)
+	case key < root.key:
+		tmp := avl.pushHelper(root.left, key)
+		tmp.parent = root
+		root.left = tmp
+	case key > root.key:
+		tmp := avl.pushHelper(root.right, key)
+		tmp.parent = root
+		root.right = tmp
 	default:
 		return root
 	}
 
 	// balance the tree
-	root.Height = avl.height(root)
+	root.height = avl.height(root)
 	bFactor := avl.balanceFactor(root)
 	if bFactor > 1 {
 		switch {
-		case key < root.Left.Key:
+		case key < root.left.key:
 			return avl.rightRotate(root)
-		case key > root.Left.Key:
-			root.Left = avl.leftRotate(root.Left)
+		case key > root.left.key:
+			root.left = avl.leftRotate(root.left)
 			return avl.rightRotate(root)
 		}
 	}
 
 	if bFactor < -1 {
 		switch {
-		case key > root.Right.Key:
+		case key > root.right.key:
 			return avl.leftRotate(root)
-		case key < root.Right.Key:
-			root.Right = avl.rightRotate(root.Right)
+		case key < root.right.key:
+			root.right = avl.rightRotate(root.right)
 			return avl.leftRotate(root)
 		}
 	}
@@ -79,57 +221,70 @@ func (avl *AVL[T]) pushHelper(root *Node[T], key T) *Node[T] {
 	return root
 }
 
-func (avl *AVL[T]) deleteHelper(root *Node[T], key T) *Node[T] {
-	if root == nil {
+func (avl *AVL[T]) deleteHelper(root *AVLNode[T], key T) *AVLNode[T] {
+	if root == avl._NIL {
 		return root
 	}
 
 	switch {
-	case key < root.Key:
-		root.Left = avl.deleteHelper(root.Left, key)
-	case key > root.Key:
-		root.Right = avl.deleteHelper(root.Right, key)
+	case key < root.key:
+		tmp := avl.deleteHelper(root.left, key)
+		root.left = tmp
+		if tmp != avl._NIL {
+			tmp.parent = root
+		}
+	case key > root.key:
+		tmp := avl.deleteHelper(root.right, key)
+		root.right = tmp
+		if tmp != avl._NIL {
+			tmp.parent = root
+		}
 	default:
-		if root.Left == nil || root.Right == nil {
-			tmp := root.Left
-			if root.Left != nil {
-				tmp = root.Right
+		if root.left == avl._NIL || root.right == avl._NIL {
+			tmp := root.left
+			if root.right != avl._NIL {
+				tmp = root.right
 			}
 
-			if tmp == nil {
-				root = nil
+			if tmp == avl._NIL {
+				root = avl._NIL
 			} else {
-				*root = *tmp
+				tmp.parent = root.parent
+				root = tmp
 			}
 		} else {
-			tmp := avl.minimum(root.Right)
-			root.Key = tmp.Key
-			root.Right = avl.deleteHelper(root.Right, tmp.Key)
+			tmp := minimum[T](root.right, avl._NIL).(*AVLNode[T])
+			root.key = tmp.key
+			del := avl.deleteHelper(root.right, tmp.key)
+			root.right = del
+			if del != avl._NIL {
+				del.parent = root
+			}
 		}
 	}
 
-	if root == nil {
+	if root == avl._NIL {
 		return root
 	}
 
 	// balance the tree
-	root.Height = avl.height(root)
+	root.height = avl.height(root)
 	bFactor := avl.balanceFactor(root)
 	switch {
 	case bFactor > 1:
 		switch {
-		case avl.balanceFactor(root.Left) >= 0:
+		case avl.balanceFactor(root.left) >= 0:
 			return avl.rightRotate(root)
 		default:
-			root.Left = avl.leftRotate(root.Left)
+			root.left = avl.leftRotate(root.left)
 			return avl.rightRotate(root)
 		}
 	case bFactor < -1:
 		switch {
-		case avl.balanceFactor(root.Right) <= 0:
+		case avl.balanceFactor(root.right) <= 0:
 			return avl.leftRotate(root)
 		default:
-			root.Right = avl.rightRotate(root.Right)
+			root.right = avl.rightRotate(root.right)
 			return avl.leftRotate(root)
 		}
 	}
@@ -137,52 +292,66 @@ func (avl *AVL[T]) deleteHelper(root *Node[T], key T) *Node[T] {
 	return root
 }
 
-func (avl *AVL[T]) height(root *Node[T]) int {
-	if root == nil {
-		return 0
+func (avl *AVL[T]) height(root *AVLNode[T]) int {
+	if root == avl._NIL {
+		return 1
 	}
 
 	var leftHeight, rightHeight int
-	if root.Left != nil {
-		leftHeight = root.Left.Height
+	if root.left != avl._NIL {
+		leftHeight = root.left.height
 	}
-	if root.Right != nil {
-		rightHeight = root.Right.Height
+	if root.right != avl._NIL {
+		rightHeight = root.right.height
 	}
 	return 1 + max.Int(leftHeight, rightHeight)
 }
 
 // balanceFactor : negative balance factor means subtree Root is heavy toward Left
 // and positive balance factor means subtree Root is heavy toward Right side
-func (avl *AVL[T]) balanceFactor(root *Node[T]) int {
+func (avl *AVL[T]) balanceFactor(root *AVLNode[T]) int {
 	var leftHeight, rightHeight int
-	if root.Left != nil {
-		leftHeight = root.Left.Height
+	if root.left != avl._NIL {
+		leftHeight = root.left.height
 	}
-	if root.Right != nil {
-		rightHeight = root.Right.Height
+	if root.right != avl._NIL {
+		rightHeight = root.right.height
 	}
 	return leftHeight - rightHeight
 }
 
-func (avl *AVL[T]) leftRotate(root *Node[T]) *Node[T] {
-	y := root.Right
-	yl := y.Left
-	y.Left = root
-	root.Right = yl
+func (avl *AVL[T]) leftRotate(x *AVLNode[T]) *AVLNode[T] {
+	y := x.right
+	yl := y.left
+	y.left = x
+	x.right = yl
 
-	root.Height = avl.height(root)
-	y.Height = avl.height(y)
+	if yl != avl._NIL {
+		yl.parent = x
+	}
+
+	y.parent = x.parent
+	x.parent = y
+
+	x.height = avl.height(x)
+	y.height = avl.height(y)
 	return y
 }
 
-func (avl *AVL[T]) rightRotate(root *Node[T]) *Node[T] {
-	y := root.Left
-	yr := y.Right
-	y.Right = root
-	root.Left = yr
+func (avl *AVL[T]) rightRotate(x *AVLNode[T]) *AVLNode[T] {
+	y := x.left
+	yr := y.right
+	y.right = x
+	x.left = yr
 
-	root.Height = avl.height(root)
-	y.Height = avl.height(y)
+	if yr != avl._NIL {
+		yr.parent = x
+	}
+
+	y.parent = x.parent
+	x.parent = y
+
+	x.height = avl.height(x)
+	y.height = avl.height(y)
 	return y
 }

--- a/structure/tree/avl_test.go
+++ b/structure/tree/avl_test.go
@@ -1,9 +1,11 @@
 package tree_test
 
 import (
-	"testing"
-
 	bt "github.com/TheAlgorithms/Go/structure/tree"
+	"math/rand"
+	"sort"
+	"testing"
+	"time"
 )
 
 func TestAVLPush(t *testing.T) {
@@ -12,51 +14,51 @@ func TestAVLPush(t *testing.T) {
 		tree.Push(5, 4, 3)
 
 		root := tree.Root
-		if root.Key != 4 {
-			t.Errorf("Root should have value = 4, not %v", root.Key)
+		if root.Key() != 4 {
+			t.Errorf("Root should have value = 4, not %v", root.Key())
 		}
-		if root.Height != 2 {
-			t.Errorf("Height of Root should be = 2, not %d", root.Height)
+		if root.Height() != 2 {
+			t.Errorf("Height of Root should be = 2, not %d", root.Height())
 		}
 
-		if root.Left.Key != 3 {
+		if root.Left().Key() != 3 {
 			t.Errorf("Left child should have value = 3")
 		}
-		if root.Left.Height != 1 {
+		if root.Left().(*bt.AVLNode[int]).Height() != 1 {
 			t.Errorf("Height of Left child should be 1")
 		}
 
-		if root.Right.Key != 5 {
+		if root.Right().Key() != 5 {
 			t.Errorf("Right child should have value = 5")
 		}
-		if root.Right.Height != 1 {
+		if root.Right().(*bt.AVLNode[int]).Height() != 1 {
 			t.Errorf("Height of Right should be 1")
 		}
-
 	})
+
 	t.Run("LRRotation-Test", func(t *testing.T) {
 		tree := bt.NewAVL[int]()
 		tree.Push(5, 3, 4)
 
 		root := tree.Root
-		if root.Key != 4 {
-			t.Errorf("Root should have value = 4")
+		if root.Key() != 4 {
+			t.Errorf("Root should have value = 4, not %v", root.Key())
 		}
-		if root.Height != 2 {
-			t.Errorf("Height of Root should be = 2")
+		if root.Height() != 2 {
+			t.Errorf("Height of Root should be = 2, not %d", root.Height())
 		}
 
-		if root.Left.Key != 3 {
+		if root.Left().Key() != 3 {
 			t.Errorf("Left child should have value = 3")
 		}
-		if root.Left.Height != 1 {
+		if root.Left().(*bt.AVLNode[int]).Height() != 1 {
 			t.Errorf("Height of Left child should be 1")
 		}
 
-		if root.Right.Key != 5 {
+		if root.Right().Key() != 5 {
 			t.Errorf("Right child should have value = 5")
 		}
-		if root.Right.Height != 1 {
+		if root.Right().(*bt.AVLNode[int]).Height() != 1 {
 			t.Errorf("Height of Right should be 1")
 		}
 	})
@@ -68,52 +70,52 @@ func TestAVLPush(t *testing.T) {
 		tree.Push(5)
 
 		root := tree.Root
-		if root.Key != 4 {
-			t.Errorf("Root should have value = 4")
+		if root.Key() != 4 {
+			t.Errorf("Root should have value = 4, not %v", root.Key())
 		}
-		if root.Height != 2 {
-			t.Errorf("Height of Root should be = 2")
+		if root.Height() != 2 {
+			t.Errorf("Height of Root should be = 2, not %d", root.Height())
 		}
 
-		if root.Left.Key != 3 {
+		if root.Left().Key() != 3 {
 			t.Errorf("Left child should have value = 3")
 		}
-		if root.Left.Height != 1 {
+		if root.Left().(*bt.AVLNode[int]).Height() != 1 {
 			t.Errorf("Height of Left child should be 1")
 		}
 
-		if root.Right.Key != 5 {
+		if root.Right().Key() != 5 {
 			t.Errorf("Right child should have value = 5")
 		}
-		if root.Right.Height != 1 {
+		if root.Right().(*bt.AVLNode[int]).Height() != 1 {
 			t.Errorf("Height of Right should be 1")
 		}
 	})
-	t.Run("RLRotaion-Test", func(t *testing.T) {
+	t.Run("RLRotation-Test", func(t *testing.T) {
 		tree := bt.NewAVL[int]()
 		tree.Push(3)
 		tree.Push(5)
 		tree.Push(4)
 
 		root := tree.Root
-		if root.Key != 4 {
+		if root.Key() != 4 {
 			t.Errorf("Root should have value = 4")
 		}
-		if root.Height != 2 {
+		if root.Height() != 2 {
 			t.Errorf("Height of Root should be = 2")
 		}
 
-		if root.Left.Key != 3 {
+		if root.Left().Key() != 3 {
 			t.Errorf("Left child should have value = 3")
 		}
-		if root.Left.Height != 1 {
+		if root.Left().(*bt.AVLNode[int]).Height() != 1 {
 			t.Errorf("Height of Left child should be 1")
 		}
 
-		if root.Right.Key != 5 {
+		if root.Right().Key() != 5 {
 			t.Errorf("Right child should have value = 5")
 		}
-		if root.Right.Height != 1 {
+		if root.Right().(*bt.AVLNode[int]).Height() != 1 {
 			t.Errorf("Height of Right should be 1")
 		}
 	})
@@ -122,6 +124,9 @@ func TestAVLPush(t *testing.T) {
 func TestAVLDelete(t *testing.T) {
 	t.Run("LLRotation-Test", func(t *testing.T) {
 		tree := bt.NewAVL[int]()
+		if tree.Delete(5) {
+			t.Errorf("There is no node, whose value is 5")
+		}
 
 		tree.Push(5)
 		tree.Push(4)
@@ -137,24 +142,24 @@ func TestAVLDelete(t *testing.T) {
 		}
 
 		root := tree.Root
-		if root.Key != 3 {
+		if root.Key() != 3 {
 			t.Errorf("Root should have value = 3")
 		}
-		if root.Height != 2 {
+		if root.Height() != 2 {
 			t.Errorf("Height of Root should be = 2")
 		}
 
-		if root.Left.Key != 2 {
+		if root.Left().Key() != 2 {
 			t.Errorf("Left child should have value = 2")
 		}
-		if root.Left.Height != 1 {
+		if root.Left().(*bt.AVLNode[int]).Height() != 1 {
 			t.Errorf("Height of Left child should be 1")
 		}
 
-		if root.Right.Key != 4 {
+		if root.Right().Key() != 4 {
 			t.Errorf("Right child should have value = 5")
 		}
-		if root.Right.Height != 1 {
+		if root.Right().(*bt.AVLNode[int]).Height() != 1 {
 			t.Errorf("Height of Right should be 1")
 		}
 	})
@@ -163,6 +168,7 @@ func TestAVLDelete(t *testing.T) {
 		tree := bt.NewAVL[int]()
 
 		tree.Push(10)
+		tree.Push(8)
 		tree.Push(8)
 		tree.Push(6)
 		tree.Push(7)
@@ -176,24 +182,24 @@ func TestAVLDelete(t *testing.T) {
 		}
 
 		root := tree.Root
-		if root.Key != 7 {
+		if root.Key() != 7 {
 			t.Errorf("Root should have value = 7")
 		}
-		if root.Height != 2 {
+		if root.Height() != 2 {
 			t.Errorf("Height of Root should be = 2")
 		}
 
-		if root.Left.Key != 6 {
+		if root.Left().Key() != 6 {
 			t.Errorf("Left child should have value = 6")
 		}
-		if root.Left.Height != 1 {
+		if root.Left().(*bt.AVLNode[int]).Height() != 1 {
 			t.Errorf("Height of Left child should be 1")
 		}
 
-		if root.Right.Key != 8 {
+		if root.Right().Key() != 8 {
 			t.Errorf("Right child should have value = 8")
 		}
-		if root.Right.Height != 1 {
+		if root.Right().(*bt.AVLNode[int]).Height() != 1 {
 			t.Errorf("Height of Right should be 1")
 		}
 
@@ -203,6 +209,7 @@ func TestAVLDelete(t *testing.T) {
 		tree := bt.NewAVL[int]()
 
 		tree.Push(2)
+		tree.Push(3)
 		tree.Push(3)
 		tree.Push(4)
 		tree.Push(5)
@@ -216,33 +223,34 @@ func TestAVLDelete(t *testing.T) {
 		}
 
 		root := tree.Root
-		if root.Key != 4 {
+		if root.Key() != 4 {
 			t.Errorf("Root should have value = 4")
 		}
-		if root.Height != 2 {
+		if root.Height() != 2 {
 			t.Errorf("Height of Root should be = 2")
 		}
 
-		if root.Left.Key != 3 {
+		if root.Left().Key() != 3 {
 			t.Errorf("Left child should have value = 3")
 		}
-		if root.Left.Height != 1 {
+		if root.Left().(*bt.AVLNode[int]).Height() != 1 {
 			t.Errorf("Height of Left child should be 1")
 		}
 
-		if root.Right.Key != 5 {
+		if root.Right().Key() != 5 {
 			t.Errorf("Right child should have value = 5")
 		}
-		if root.Right.Height != 1 {
+		if root.Right().(*bt.AVLNode[int]).Height() != 1 {
 			t.Errorf("Height of Right should be 1")
 		}
 
 	})
 
-	t.Run("RLRotaion-Test", func(t *testing.T) {
+	t.Run("RLRotation-Test", func(t *testing.T) {
 		tree := bt.NewAVL[int]()
 
 		tree.Push(7)
+		tree.Push(6)
 		tree.Push(6)
 		tree.Push(9)
 		tree.Push(8)
@@ -250,26 +258,64 @@ func TestAVLDelete(t *testing.T) {
 		tree.Delete(6)
 
 		root := tree.Root
-		if root.Key != 8 {
+		if root.Key() != 8 {
 			t.Errorf("Root should have value = 8")
 		}
-		if root.Height != 2 {
+		if root.Height() != 2 {
 			t.Errorf("Height of Root should be = 2")
 		}
 
-		if root.Left.Key != 7 {
+		if root.Left().Key() != 7 {
 			t.Errorf("Left child should have value = 7")
 		}
-		if root.Left.Height != 1 {
+		if root.Left().(*bt.AVLNode[int]).Height() != 1 {
 			t.Errorf("Height of Left child should be 1")
 		}
 
-		if root.Right.Key != 9 {
+		if root.Right().Key() != 9 {
 			t.Errorf("Right child should have value = 9")
 		}
-		if root.Right.Height != 1 {
+		if root.Right().(*bt.AVLNode[int]).Height() != 1 {
 			t.Errorf("Height of Right should be 1")
 		}
 
+	})
+
+	t.Run("Random Test", func(t *testing.T) {
+		nums := []int{100, 500, 1000, 10_000}
+		for _, n := range nums {
+			rand.Seed(time.Now().Unix())
+			tree := bt.NewAVL[int]()
+			nums := rand.Perm(n)
+			tree.Push(nums...)
+
+			rets := tree.InOrder()
+			if !sort.IntsAreSorted(rets) {
+				t.Error("Error with Push")
+			}
+
+			if res, ok := tree.Min(); !ok || res != rets[0] {
+				t.Errorf("Error with Min, get %d, want: %d", res, rets[0])
+			}
+
+			if res, ok := tree.Max(); !ok || res != rets[n-1] {
+				t.Errorf("Error with Max, get %d, want: %d", res, rets[n-1])
+			}
+
+			for i := 0; i < n-1; i++ {
+				if ret, ok := tree.Successor(rets[0]); ret != rets[1] || !ok {
+					t.Error("Error with Successor")
+				}
+				if ret, ok := tree.Predecessor(rets[1]); ret != rets[0] || !ok {
+					t.Error("Error with Predecessor")
+				}
+
+				ok := tree.Delete(nums[i])
+				rets = tree.InOrder()
+				if !ok || !sort.IntsAreSorted(rets) {
+					t.Errorf("Error With Delete")
+				}
+			}
+		}
 	})
 }

--- a/structure/tree/bstree.go
+++ b/structure/tree/bstree.go
@@ -6,73 +6,223 @@
 
 package tree
 
-import (
-	"github.com/TheAlgorithms/Go/constraints"
-)
+import "github.com/TheAlgorithms/Go/constraints"
 
-type BinarySearch[T constraints.Ordered] struct {
-	*binaryTree[T]
+// Verify Interface Compliance
+var _ Node[int] = &BSNode[int]{}
+
+// BSNode represents a single node in the BinarySearch.
+type BSNode[T constraints.Ordered] struct {
+	key    T
+	parent *BSNode[T]
+	left   *BSNode[T]
+	right  *BSNode[T]
 }
 
-// NewBinarySearch create a novel Binary-Search tree
+func (n *BSNode[T]) Key() T {
+	return n.key
+}
+
+func (n *BSNode[T]) Parent() Node[T] {
+	return n.parent
+}
+
+func (n *BSNode[T]) Left() Node[T] {
+	return n.left
+}
+
+func (n *BSNode[T]) Right() Node[T] {
+	return n.right
+}
+
+// BinarySearch represents a Binary-Search tree.
+// By default, _NIL = nil.
+type BinarySearch[T constraints.Ordered] struct {
+	Root *BSNode[T]
+	_NIL *BSNode[T] // a sentinel value for nil
+}
+
+// NewBinarySearch creates a novel Binary-Search tree
 func NewBinarySearch[T constraints.Ordered]() *BinarySearch[T] {
 	return &BinarySearch[T]{
-		binaryTree: &binaryTree[T]{
-			Root: nil,
-			NIL:  nil,
-		},
+		Root: nil,
+		_NIL: nil,
 	}
+}
+
+// Empty determines the Binary-Search tree is empty
+func (t *BinarySearch[T]) Empty() bool {
+	return t.Root == t._NIL
 }
 
 // Push a chain of Node's into the BinarySearch
 func (t *BinarySearch[T]) Push(keys ...T) {
 	for _, key := range keys {
-		t.Root = t.pushHelper(t.Root, key)
+		t.pushHelper(t.Root, key)
 	}
 }
 
 // Delete removes the node of val
 func (t *BinarySearch[T]) Delete(val T) bool {
-	if !t.Has(val) {
+	node, ok := t.Get(val)
+	if !ok {
 		return false
 	}
-	t.deleteHelper(t.Root, val)
+	t.deleteHelper(node.(*BSNode[T]))
 	return true
 }
 
-func (t *BinarySearch[T]) pushHelper(root *Node[T], val T) *Node[T] {
-	if root == nil {
-		return &Node[T]{Key: val, Left: nil, Right: nil}
-	}
-	if val < root.Key {
-		root.Left = t.pushHelper(root.Left, val)
-	} else {
-		root.Right = t.pushHelper(root.Right, val)
-	}
-	return root
+// Get a Node from the Binary-Search Tree
+func (t *BinarySearch[T]) Get(key T) (Node[T], bool) {
+	return searchTreeHelper[T](t.Root, t._NIL, key)
 }
 
-func (t *BinarySearch[T]) deleteHelper(root *Node[T], val T) *Node[T] {
-	if root == nil {
-		return nil
+// Has Determines the tree has the node of Key
+func (t *BinarySearch[T]) Has(key T) bool {
+	_, ok := searchTreeHelper[T](t.Root, t._NIL, key)
+	return ok
+}
+
+// PreOrder Traverses the tree in the following order Root --> Left --> Right
+func (t *BinarySearch[T]) PreOrder() []T {
+	traversal := make([]T, 0)
+	preOrderRecursive[T](t.Root, t._NIL, &traversal)
+	return traversal
+}
+
+// InOrder Traverses the tree in the following order Left --> Root --> Right
+func (t *BinarySearch[T]) InOrder() []T {
+	return inOrderHelper[T](t.Root, t._NIL)
+}
+
+// PostOrder traverses the tree in the following order Left --> Right --> Root
+func (t *BinarySearch[T]) PostOrder() []T {
+	traversal := make([]T, 0)
+	postOrderRecursive[T](t.Root, t._NIL, &traversal)
+	return traversal
+}
+
+// LevelOrder returns the level order traversal of the tree
+func (t *BinarySearch[T]) LevelOrder() []T {
+	traversal := make([]T, 0)
+	levelOrderHelper[T](t.Root, t._NIL, &traversal)
+	return traversal
+}
+
+// AccessNodesByLayer accesses nodes layer by layer (2-D array),  instead of printing the results as 1-D array.
+func (t *BinarySearch[T]) AccessNodesByLayer() [][]T {
+	return accessNodeByLayerHelper[T](t.Root, t._NIL)
+}
+
+// Depth returns the calculated depth of a binary search tree
+func (t *BinarySearch[T]) Depth() int {
+	return calculateDepth[T](t.Root, t._NIL, 0)
+}
+
+// Max returns the Max value of the tree
+func (t *BinarySearch[T]) Max() (T, bool) {
+	ret := maximum[T](t.Root, t._NIL)
+	if ret == t._NIL {
+		var dft T
+		return dft, false
 	}
-	if val < root.Key {
-		root.Left = t.deleteHelper(root.Left, val)
-	} else if val > root.Key {
-		root.Right = t.deleteHelper(root.Right, val)
-	} else {
-		// this is the node to delete
-		// node with one child
-		if root.Left == nil {
-			return root.Right
-		} else if root.Right == nil {
-			return root.Left
-		} else {
-			n := root.Right
-			d := t.minimum(n)
-			d.Left = root.Left
-			return root.Right
+	return ret.Key(), true
+}
+
+// Min returns the Min value of the tree
+func (t *BinarySearch[T]) Min() (T, bool) {
+	ret := minimum[T](t.Root, t._NIL)
+	if ret == t._NIL {
+		var dft T
+		return dft, false
+	}
+	return ret.Key(), true
+}
+
+// Predecessor returns the Predecessor of the node of Key
+// if there is no predecessor, return default value of type T and false
+// otherwise return the Key of predecessor and true
+func (t *BinarySearch[T]) Predecessor(key T) (T, bool) {
+	node, ok := searchTreeHelper[T](t.Root, t._NIL, key)
+	if !ok {
+		var dft T
+		return dft, ok
+	}
+	return predecessorHelper[T](node, t._NIL)
+}
+
+// Successor returns the Successor of the node of Key
+// if there is no successor, return default value of type T and false
+// otherwise return the Key of successor and true
+func (t *BinarySearch[T]) Successor(key T) (T, bool) {
+	node, ok := searchTreeHelper[T](t.Root, t._NIL, key)
+	if !ok {
+		var dft T
+		return dft, ok
+	}
+	return successorHelper[T](node, t._NIL)
+}
+
+func (t *BinarySearch[T]) pushHelper(x *BSNode[T], val T) {
+	y := t._NIL
+	for x != t._NIL {
+		y = x
+		switch {
+		case val < x.Key():
+			x = x.left
+		case val > x.Key():
+			x = x.right
+		default:
+			return
 		}
 	}
-	return root
+
+	z := &BSNode[T]{
+		key:    val,
+		left:   t._NIL,
+		right:  t._NIL,
+		parent: y,
+	}
+	if y == t._NIL {
+		t.Root = z
+	} else if val < y.key {
+		y.left = z
+	} else {
+		y.right = z
+	}
+}
+
+func (t *BinarySearch[T]) deleteHelper(z *BSNode[T]) {
+	switch {
+	case z.left == t._NIL:
+		t.transplant(z, z.right)
+	case z.right == t._NIL:
+		t.transplant(z, z.left)
+	default:
+		y := minimum[T](z.right, t._NIL).(*BSNode[T])
+		if y.parent != z {
+			t.transplant(y, y.right)
+			y.right = z.right
+			y.right.parent = y
+		}
+
+		t.transplant(z, y)
+		y.left = z.left
+		y.left.parent = y
+	}
+}
+
+func (t *BinarySearch[T]) transplant(u, v *BSNode[T]) {
+	switch {
+	case u.parent == t._NIL:
+		t.Root = v
+	case u == u.parent.left:
+		u.parent.left = v
+	default:
+		u.parent.right = v
+	}
+
+	if v != t._NIL {
+		v.parent = u.parent
+	}
 }

--- a/structure/tree/bstree_test.go
+++ b/structure/tree/bstree_test.go
@@ -1,7 +1,10 @@
 package tree_test
 
 import (
+	"math/rand"
+	"sort"
 	"testing"
+	"time"
 
 	bt "github.com/TheAlgorithms/Go/structure/tree"
 )
@@ -13,15 +16,15 @@ func TestPush(t *testing.T) {
 	bst.Push(80)
 	bst.Push(100)
 
-	if bst.Root.Key != 90 {
+	if bst.Root.Key() != 90 {
 		t.Errorf("Root should have value = 90")
 	}
 
-	if bst.Root.Left.Key != 80 {
+	if bst.Root.Left().Key() != 80 {
 		t.Errorf("Left child should have value = 80")
 	}
 
-	if bst.Root.Right.Key != 100 {
+	if bst.Root.Right().Key() != 100 {
 		t.Errorf("Right child should have value = 100")
 	}
 
@@ -36,6 +39,7 @@ func TestDelete(t *testing.T) {
 
 		bst.Push(90)
 		bst.Push(80)
+		bst.Push(80)
 		bst.Push(100)
 
 		if !bst.Delete(100) {
@@ -47,15 +51,15 @@ func TestDelete(t *testing.T) {
 		}
 
 		root := bst.Root
-		if root.Key != 90 {
+		if root.Key() != 90 {
 			t.Errorf("Root should have value = 90")
 		}
 
-		if root.Left.Key != 80 {
+		if root.Left().Key() != 80 {
 			t.Errorf("Left child should have value = 80")
 		}
 
-		if root.Right != nil {
+		if root.Right().(*bt.BSNode[int]) != nil {
 			t.Errorf("Right child should have value = nil")
 		}
 
@@ -65,11 +69,11 @@ func TestDelete(t *testing.T) {
 
 		bst.Delete(80)
 
-		if root.Key != 90 {
+		if root.Key() != 90 {
 			t.Errorf("Root should have value = 90")
 		}
 
-		if root.Left != nil {
+		if root.Left().(*bt.BSNode[int]) != nil {
 			t.Errorf("Left child should have value = nil")
 		}
 
@@ -95,15 +99,15 @@ func TestDelete(t *testing.T) {
 		}
 
 		root := bst.Root
-		if root.Key != 90 {
+		if root.Key() != 90 {
 			t.Errorf("Root should have value = 90")
 		}
 
-		if root.Right.Key != 100 {
+		if root.Right().Key() != 100 {
 			t.Errorf("Right child should have value = 100")
 		}
 
-		if root.Left.Key != 70 {
+		if root.Left().Key() != 70 {
 			t.Errorf("Left child should have value = 70")
 		}
 
@@ -130,20 +134,59 @@ func TestDelete(t *testing.T) {
 		}
 
 		root := bst.Root
-		if root.Key != 90 {
+		if root.Key() != 90 {
 			t.Errorf("Root should have value = 90")
 		}
 
-		if root.Left.Key != 85 {
+		if root.Left().Key() != 85 {
 			t.Errorf("Left child should have value = 85")
 		}
 
-		if root.Right.Key != 100 {
+		if root.Right().Key() != 100 {
 			t.Errorf("Right child should have value = 100")
 		}
 
 		if bst.Depth() != 3 {
 			t.Errorf("Depth should have value = 3")
+		}
+	})
+
+	t.Run("Random Test", func(t *testing.T) {
+		tests := []int{100, 500, 1000, 10_000}
+		for _, n := range tests {
+			rand.Seed(time.Now().Unix())
+			tree := bt.NewBinarySearch[int]()
+			nums := rand.Perm(n)
+			tree.Push(nums...)
+
+			rets := tree.InOrder()
+			if !sort.IntsAreSorted(rets) {
+				t.Error("Error with Push")
+			}
+
+			if res, ok := tree.Min(); !ok || res != rets[0] {
+				t.Errorf("Error with Min, get %d, want: %d", res, rets[0])
+			}
+
+			if res, ok := tree.Max(); !ok || res != rets[n-1] {
+				t.Errorf("Error with Max, get %d, want: %d", res, rets[n-1])
+			}
+
+			for i := 0; i < n-1; i++ {
+				if ret, ok := tree.Successor(rets[0]); ret != rets[1] || !ok {
+					t.Error("Error with Successor")
+				}
+
+				if ret, ok := tree.Predecessor(rets[1]); ret != rets[0] || !ok {
+					t.Error("Error with Predecessor")
+				}
+
+				ok := tree.Delete(nums[i])
+				rets = tree.InOrder()
+				if !ok || !sort.IntsAreSorted(rets) {
+					t.Errorf("Error With Delete")
+				}
+			}
 		}
 	})
 }

--- a/structure/tree/example_test.go
+++ b/structure/tree/example_test.go
@@ -1,0 +1,167 @@
+package tree_test
+
+import (
+	"fmt"
+	"github.com/TheAlgorithms/Go/constraints"
+	"testing"
+
+	bt "github.com/TheAlgorithms/Go/structure/tree"
+)
+
+type TestTree[T constraints.Ordered] interface {
+	Push(...T)
+	Delete(T) bool
+	Get(T) (bt.Node[T], bool)
+	Empty() bool
+	Has(T) bool
+	Depth() int
+	Max() (T, bool)
+	Min() (T, bool)
+	Predecessor(T) (T, bool)
+	Successor(T) (T, bool)
+	PreOrder() []T
+	InOrder() []T
+	PostOrder() []T
+	LevelOrder() []T
+	AccessNodesByLayer() [][]T
+}
+
+// BinarySearch, AVL and RB have completed the `TestTree` interface.
+var (
+	_ TestTree[int] = (*bt.BinarySearch[int])(nil)
+	_ TestTree[int] = (*bt.AVL[int])(nil)
+	_ TestTree[int] = (*bt.RB[int])(nil)
+)
+
+var tree TestTree[int]
+
+func TestBinarySearch(t *testing.T) {
+	tree = bt.NewBinarySearch[int]()
+
+	if tree.Empty() {
+		t.Log("Binary Search Tree is empty now.")
+	}
+
+	tree.Push(1, 4, 10)
+	tree.Push(-8)
+	nums := []int{87, 18, 10, -34}
+	tree.Push(nums...)
+	tree.Push(4) // duplicate key, dismiss it
+
+	if tree.Has(4) {
+		t.Logf("There is a node of 4")
+	}
+
+	if n, ok := tree.Get(10); ok {
+		t.Logf("node of 10: %T", n)
+	}
+
+	if ret, ok := tree.Min(); ok {
+		t.Logf("tree.Min() = %v", ret)
+	}
+
+	if ret, ok := tree.Max(); ok {
+		t.Logf("tree.Max() = %v", ret)
+	}
+
+	if ret, ok := tree.Predecessor(1); ok {
+		t.Logf("tree.Preducessor(1) = %v", ret)
+	}
+
+	if ret, ok := tree.Successor(18); ok {
+		t.Logf("tree.Successor(18) = %v", ret)
+	}
+
+	fmt.Println(tree.InOrder())
+	fmt.Println(tree.AccessNodesByLayer())
+
+	tree.Delete(18)
+	fmt.Println("Delete 18")
+	fmt.Println(tree.InOrder())
+}
+
+func TestAVL(t *testing.T) {
+	tree = bt.NewAVL[int]()
+
+	if tree.Empty() {
+		t.Log("AVL Tree is empty now.")
+	}
+
+	tree.Push(1, 4, 10)
+	tree.Push(-8)
+	nums := []int{87, 18, 10, -34}
+	tree.Push(nums...)
+	tree.Push(4) // duplicate key, dismiss it
+
+	if tree.Has(4) {
+		t.Logf("There is a node of 4")
+	}
+
+	if n, ok := tree.Get(10); ok {
+		t.Logf("node of 10: %T", n)
+	}
+
+	if ret, ok := tree.Min(); ok {
+		t.Logf("tree.Min() = %v", ret)
+	}
+
+	if ret, ok := tree.Max(); ok {
+		t.Logf("tree.Max() = %v", ret)
+	}
+
+	if ret, ok := tree.Predecessor(1); ok {
+		t.Logf("tree.Preducessor(1) = %v", ret)
+	}
+
+	if ret, ok := tree.Successor(18); ok {
+		t.Logf("tree.Successor(18) = %v", ret)
+	}
+
+	fmt.Println(tree.InOrder())
+	fmt.Println(tree.AccessNodesByLayer())
+
+	tree.Delete(18)
+	fmt.Println("Delete 18")
+	fmt.Println(tree.InOrder())
+}
+
+func TestRB(t *testing.T) {
+	tree = bt.NewRB[int]()
+
+	if tree.Empty() {
+		t.Log("RB Tree is empty now.")
+	}
+
+	tree.Push(1, 4, 10)
+	tree.Push(-8)
+	nums := []int{87, 18, 10, -34}
+	tree.Push(nums...)
+	tree.Push(4) // duplicate key, dismiss it
+
+	if tree.Has(4) {
+		t.Logf("There is a node of 4")
+	}
+
+	if n, ok := tree.Get(10); ok {
+		t.Logf("node of 10: %T", n)
+	}
+
+	if ret, ok := tree.Min(); ok {
+		t.Logf("tree.Min() = %v", ret)
+	}
+
+	if ret, ok := tree.Max(); ok {
+		t.Logf("tree.Max() = %v", ret)
+	}
+
+	if ret, ok := tree.Predecessor(1); ok {
+		t.Logf("tree.Preducessor(1) = %v", ret)
+	}
+
+	if ret, ok := tree.Successor(18); ok {
+		t.Logf("tree.Successor(18) = %v", ret)
+	}
+
+	fmt.Println(tree.InOrder())
+	fmt.Println(tree.AccessNodesByLayer())
+}

--- a/structure/tree/rbtree.go
+++ b/structure/tree/rbtree.go
@@ -1,5 +1,5 @@
 // Red-Black Tree is a kind of self-balancing binary search tree.
-// Each node stores "Color" ("red" or "black"), used to ensure that the tree remains balanced during insertions and deletions.
+// Each node stores "color" ("red" or "black"), used to ensure that the tree remains balanced during insertions and deletions.
 //
 // For more details check out those links below here:
 // Programiz article : https://www.programiz.com/dsa/red-black-tree
@@ -9,25 +9,63 @@
 
 package tree
 
-import (
-	"fmt"
+import "github.com/TheAlgorithms/Go/constraints"
 
-	"github.com/TheAlgorithms/Go/constraints"
+type Color byte
+
+const (
+	Red Color = iota
+	Black
 )
 
-type RB[T constraints.Ordered] struct {
-	*binaryTree[T]
+// Verify Interface Compliance
+var _ Node[int] = &RBNode[int]{}
+
+// RBNode represents a single node in the RB.
+type RBNode[T constraints.Ordered] struct {
+	key    T
+	parent *RBNode[T]
+	left   *RBNode[T]
+	right  *RBNode[T]
+	color  Color
 }
 
-// Create a new Red-Black Tree
+func (n *RBNode[T]) Key() T {
+	return n.key
+}
+
+func (n *RBNode[T]) Parent() Node[T] {
+	return n.parent
+}
+
+func (n *RBNode[T]) Left() Node[T] {
+	return n.left
+}
+
+func (n *RBNode[T]) Right() Node[T] {
+	return n.right
+}
+
+// RB represents a Red-Black tree.
+// By default, _NIL = leaf, a dummy variable.
+type RB[T constraints.Ordered] struct {
+	Root *RBNode[T]
+	_NIL *RBNode[T] // a sentinel value for nil
+}
+
+// NewRB creates a new Red-Black Tree
 func NewRB[T constraints.Ordered]() *RB[T] {
-	leaf := &Node[T]{Color: Black, Left: nil, Right: nil}
+	leaf := &RBNode[T]{color: Black, left: nil, right: nil}
+	leaf.parent = leaf
 	return &RB[T]{
-		binaryTree: &binaryTree[T]{
-			Root: leaf,
-			NIL:  leaf,
-		},
+		Root: leaf,
+		_NIL: leaf,
 	}
+}
+
+// Empty determines the Red-Black tree is empty
+func (t *RB[T]) Empty() bool {
+	return t.Root == t._NIL
 }
 
 // Push a chain of Node's into the Red-Black Tree
@@ -43,145 +81,212 @@ func (t *RB[T]) Delete(data T) bool {
 	return t.deleteHelper(t.Root, data)
 }
 
-// Return the Predecessor of the node of Key
+// Get a Node from the Red-Black Tree
+func (t *RB[T]) Get(key T) (Node[T], bool) {
+	return searchTreeHelper[T](t.Root, t._NIL, key)
+}
+
+// Has Determines the tree has the node of Key
+func (t *RB[T]) Has(key T) bool {
+	_, ok := searchTreeHelper[T](t.Root, t._NIL, key)
+	return ok
+}
+
+// PreOrder Traverses the tree in the following order Root --> Left --> Right
+func (t *RB[T]) PreOrder() []T {
+	traversal := make([]T, 0)
+	preOrderRecursive[T](t.Root, t._NIL, &traversal)
+	return traversal
+}
+
+// InOrder Traverses the tree in the following order Left --> Root --> Right
+func (t *RB[T]) InOrder() []T {
+	return inOrderHelper[T](t.Root, t._NIL)
+}
+
+// PostOrder traverses the tree in the following order Left --> Right --> Root
+func (t *RB[T]) PostOrder() []T {
+	traversal := make([]T, 0)
+	postOrderRecursive[T](t.Root, t._NIL, &traversal)
+	return traversal
+}
+
+// LevelOrder returns the level order traversal of the tree
+func (t *RB[T]) LevelOrder() []T {
+	traversal := make([]T, 0)
+	levelOrderHelper[T](t.Root, t._NIL, &traversal)
+	return traversal
+}
+
+// AccessNodesByLayer accesses nodes layer by layer (2-D array),  instead of printing the results as 1-D array.
+func (t *RB[T]) AccessNodesByLayer() [][]T {
+	return accessNodeByLayerHelper[T](t.Root, t._NIL)
+}
+
+// Depth returns the calculated depth of a Red-Black tree
+func (t *RB[T]) Depth() int {
+	return calculateDepth[T](t.Root, t._NIL, 0)
+}
+
+// Max returns the Max value of the tree
+func (t *RB[T]) Max() (T, bool) {
+	ret := maximum[T](t.Root, t._NIL)
+	if ret == t._NIL {
+		var dft T
+		return dft, false
+	}
+	return ret.Key(), true
+}
+
+// Min returns the Min value of the tree
+func (t *RB[T]) Min() (T, bool) {
+	ret := minimum[T](t.Root, t._NIL)
+	if ret == t._NIL {
+		var dft T
+		return dft, false
+	}
+	return ret.Key(), true
+}
+
+// Predecessor returns the Predecessor of the node of Key
 // if there is no predecessor, return default value of type T and false
 // otherwise return the Key of predecessor and true
 func (t *RB[T]) Predecessor(key T) (T, bool) {
-	node, ok := t.searchTreeHelper(t.Root, key)
+	node, ok := searchTreeHelper[T](t.Root, t._NIL, key)
 	if !ok {
-		return t.NIL.Key, ok
+		var dft T
+		return dft, ok
 	}
-	return t.predecessorHelper(node)
+	return predecessorHelper[T](node, t._NIL)
 }
 
-// Return the Successor of the node of Key
+// Successor returns the Successor of the node of Key
 // if there is no successor, return default value of type T and false
 // otherwise return the Key of successor and true
 func (t *RB[T]) Successor(key T) (T, bool) {
-	node, ok := t.searchTreeHelper(t.Root, key)
+	node, ok := searchTreeHelper[T](t.Root, t._NIL, key)
 	if !ok {
-		return t.NIL.Key, ok
+		var dft T
+		return dft, ok
 	}
-
-	return t.successorHelper(node)
+	return successorHelper[T](node, t._NIL)
 }
 
-func (t *RB[T]) pushHelper(x *Node[T], key T) {
-	node := &Node[T]{
-		Key:    key,
-		Left:   t.NIL,
-		Right:  t.NIL,
-		Parent: nil,
-		Color:  Red,
-	}
-
-	var y *Node[T]
-	for !t.isNil(x) {
+func (t *RB[T]) pushHelper(x *RBNode[T], key T) {
+	y := t._NIL
+	for x != t._NIL {
 		y = x
-		if node.Key < x.Key {
-			x = x.Left
-		} else {
-			x = x.Right
+		switch {
+		case key < x.Key():
+			x = x.left
+		case key > x.Key():
+			x = x.right
+		default:
+			return
 		}
-
 	}
 
-	node.Parent = y
-	if y == nil {
+	node := &RBNode[T]{
+		key:    key,
+		left:   t._NIL,
+		right:  t._NIL,
+		parent: y,
+		color:  Red,
+	}
+	if y == t._NIL {
 		t.Root = node
-	} else if node.Key < y.Key {
-		y.Left = node
+	} else if node.key < y.key {
+		y.left = node
 	} else {
-		y.Right = node
+		y.right = node
 	}
 
-	if node.Parent == nil {
-		node.Color = Black
+	if node.parent == t._NIL {
+		node.color = Black
 		return
 	}
 
-	if node.Parent.Parent == nil {
+	if node.parent.parent == t._NIL {
 		return
 	}
 
 	t.pushFix(node)
 }
 
-func (t *RB[T]) leftRotate(x *Node[T]) {
-	y := x.Right
-	x.Right = y.Left
+func (t *RB[T]) leftRotate(x *RBNode[T]) {
+	y := x.right
+	x.right = y.left
 
-	if !t.isNil(y.Left) {
-		y.Left.Parent = x
+	if y.left != t._NIL {
+		y.left.parent = x
 	}
 
-	y.Parent = x.Parent
-	if x.Parent == nil {
+	y.parent = x.parent
+	if x.parent == t._NIL {
 		t.Root = y
-	} else if x == x.Parent.Left {
-		x.Parent.Left = y
+	} else if x == x.parent.left {
+		x.parent.left = y
 	} else {
-		x.Parent.Right = y
+		x.parent.right = y
 	}
 
-	y.Left = x
-	x.Parent = y
+	y.left = x
+	x.parent = y
 }
 
-func (t *RB[T]) rightRotate(x *Node[T]) {
-	y := x.Left
-	x.Left = y.Right
-	if !t.isNil(y.Right) {
-		y.Right.Parent = x
+func (t *RB[T]) rightRotate(x *RBNode[T]) {
+	y := x.left
+	x.left = y.right
+	if y.right != t._NIL {
+		y.right.parent = x
 	}
 
-	y.Parent = x.Parent
-	if x.Parent == nil {
+	y.parent = x.parent
+	if x.parent == t._NIL {
 		t.Root = y
-	} else if x == y.Parent.Right {
-		y.Parent.Right = y
+	} else if x == y.parent.right {
+		y.parent.right = y
 	} else {
-		y.Parent.Left = y
+		y.parent.left = y
 	}
 
-	y.Right = x
-	x.Parent = y
+	y.right = x
+	x.parent = y
 }
 
-func (t *RB[T]) pushFix(k *Node[T]) {
-	var u *Node[T]
-	for k.Parent.Color == Red {
-		if k.Parent == k.Parent.Parent.Right {
-			u = k.Parent.Parent.Left
-			if u != nil && u.Color == Red {
-				u.Color = Black
-				k.Parent.Color = Black
-				k.Parent.Parent.Color = Red
-				k = k.Parent.Parent
+func (t *RB[T]) pushFix(k *RBNode[T]) {
+	for k.parent.color == Red {
+		if k.parent == k.parent.parent.right {
+			u := k.parent.parent.left
+			if u.color == Red {
+				u.color = Black
+				k.parent.color = Black
+				k.parent.parent.color = Red
+				k = k.parent.parent
 			} else {
-				if k == k.Parent.Left {
-					k = k.Parent
+				if k == k.parent.left {
+					k = k.parent
 					t.rightRotate(k)
 				}
-				k.Parent.Color = Black
-				k.Parent.Parent.Color = Red
-				t.leftRotate(k.Parent.Parent)
+				k.parent.color = Black
+				k.parent.parent.color = Red
+				t.leftRotate(k.parent.parent)
 			}
 		} else {
-			u = k.Parent.Parent.Right
-			if u != nil && u.Color == Red {
-				u.Color = Black
-				k.Parent.Color = Black
-				k.Parent.Parent.Color = Red
-				k = k.Parent.Parent
+			u := k.parent.parent.right
+			if u.color == Red {
+				u.color = Black
+				k.parent.color = Black
+				k.parent.parent.color = Red
+				k = k.parent.parent
 			} else {
-				if k == k.Parent.Right {
-					k = k.Parent
+				if k == k.parent.right {
+					k = k.parent
 					t.leftRotate(k)
 				}
-				k.Parent.Color = Black
-				k.Parent.Parent.Color = Red
-				t.rightRotate(k.Parent.Parent)
+				k.parent.color = Black
+				k.parent.parent.color = Red
+				t.rightRotate(k.parent.parent)
 			}
 		}
 		if k == t.Root {
@@ -189,53 +294,52 @@ func (t *RB[T]) pushFix(k *Node[T]) {
 		}
 	}
 
-	t.Root.Color = Black
+	t.Root.color = Black
 }
 
-func (t *RB[T]) deleteHelper(node *Node[T], key T) bool {
-	z := t.NIL
-	for !t.isNil(node) {
+func (t *RB[T]) deleteHelper(node *RBNode[T], key T) bool {
+	z := t._NIL
+	for node != t._NIL {
 		switch {
-		case node.Key == key:
+		case node.key == key:
 			z = node
 			fallthrough
-		case node.Key <= key:
-			node = node.Right
-		case node.Key > key:
-			node = node.Left
+		case node.key <= key:
+			node = node.right
+		case node.key > key:
+			node = node.left
 		}
 	}
 
-	if t.isNil(z) {
-		fmt.Println("Key not found in the tree")
+	if z == t._NIL {
 		return false
 	}
 
-	var x *Node[T]
+	var x *RBNode[T]
 	y := z
-	yOriginColor := y.Color
-	if t.isNil(z.Left) {
-		x = z.Right
-		t.rbTransplant(z, z.Right)
-	} else if t.isNil(z.Right) {
-		x = z.Left
-		t.rbTransplant(z, z.Left)
+	yOriginColor := y.color
+	if z.left == t._NIL {
+		x = z.right
+		t.transplant(z, z.right)
+	} else if z.right == t._NIL {
+		x = z.left
+		t.transplant(z, z.left)
 	} else {
-		y = t.minimum(z.Right)
-		yOriginColor = y.Color
-		x = y.Right
-		if y.Parent == z {
-			x.Parent = y
+		y = minimum[T](z.right, t._NIL).(*RBNode[T])
+		yOriginColor = y.color
+		x = y.right
+		if y.parent == z {
+			x.parent = y
 		} else {
-			t.rbTransplant(y, y.Right)
-			y.Right = z.Right
-			y.Right.Parent = y
+			t.transplant(y, y.right)
+			y.right = z.right
+			y.right.parent = y
 		}
 
-		t.rbTransplant(z, y)
-		y.Left = z.Left
-		y.Left.Parent = y
-		y.Color = z.Color
+		t.transplant(z, y)
+		y.left = z.left
+		y.left.parent = y
+		y.color = z.color
 	}
 
 	if yOriginColor == Black {
@@ -245,109 +349,76 @@ func (t *RB[T]) deleteHelper(node *Node[T], key T) bool {
 	return true
 }
 
-func (t *RB[T]) deleteFix(x *Node[T]) {
-	var s *Node[T]
-	for x != t.Root && x.Color == Black {
-		if x == x.Parent.Left {
-			s = x.Parent.Right
-			if s.Color == Red {
-				s.Color = Black
-				x.Parent.Color = Red
-				t.leftRotate(x.Parent)
-				s = x.Parent.Right
+func (t *RB[T]) deleteFix(x *RBNode[T]) {
+	var s *RBNode[T]
+	for x != t.Root && x.color == Black {
+		if x == x.parent.left {
+			s = x.parent.right
+			if s.color == Red {
+				s.color = Black
+				x.parent.color = Red
+				t.leftRotate(x.parent)
+				s = x.parent.right
 			}
 
-			if s.Left.Color == Black && s.Right.Color == Black {
-				s.Color = Red
-				x = x.Parent
+			if s.left.color == Black && s.right.color == Black {
+				s.color = Red
+				x = x.parent
 			} else {
-				if s.Right.Color == Black {
-					s.Left.Color = Black
-					s.Color = Red
+				if s.right.color == Black {
+					s.left.color = Black
+					s.color = Red
 					t.rightRotate(s)
-					s = x.Parent.Right
+					s = x.parent.right
 				}
 
-				s.Color = x.Parent.Color
-				x.Parent.Color = Black
-				s.Right.Color = Black
-				t.leftRotate(x.Parent)
+				s.color = x.parent.color
+				x.parent.color = Black
+				s.right.color = Black
+				t.leftRotate(x.parent)
 				x = t.Root
 			}
 		} else {
-			s = x.Parent.Left
-			if s.Color == Red {
-				s.Color = Black
-				x.Parent.Color = Red
-				t.rightRotate(x.Parent)
-				s = x.Parent.Left
+			s = x.parent.left
+			if s.color == Red {
+				s.color = Black
+				x.parent.color = Red
+				t.rightRotate(x.parent)
+				s = x.parent.left
 			}
 
-			if s.Right.Color == Black && s.Left.Color == Black {
-				s.Color = Red
-				x = x.Parent
+			if s.right.color == Black && s.left.color == Black {
+				s.color = Red
+				x = x.parent
 			} else {
-				if s.Left.Color == Black {
-					s.Right.Color = Black
-					s.Color = Red
+				if s.left.color == Black {
+					s.right.color = Black
+					s.color = Red
 					t.leftRotate(s)
-					s = x.Parent.Left
+					s = x.parent.left
 				}
 
-				s.Color = x.Parent.Color
-				x.Parent.Color = Black
-				s.Left.Color = Black
-				t.rightRotate(x.Parent)
+				s.color = x.parent.color
+				x.parent.color = Black
+				s.left.color = Black
+				t.rightRotate(x.parent)
 				x = t.Root
 			}
 		}
 	}
 
-	x.Color = Black
+	x.color = Black
 }
 
-func (t *RB[T]) rbTransplant(u, v *Node[T]) {
+func (t *RB[T]) transplant(u, v *RBNode[T]) {
 	switch {
-	case u.Parent == nil:
+	case u.parent == t._NIL:
 		t.Root = v
-	case u == u.Parent.Left:
-		u.Parent.Left = v
+	case u == u.parent.left:
+		u.parent.left = v
 	default:
-		u.Parent.Right = v
-	}
-	v.Parent = u.Parent
-}
-
-func (t *RB[T]) predecessorHelper(node *Node[T]) (T, bool) {
-	if !t.isNil(node.Left) {
-		return t.maximum(node.Left).Key, true
+		u.parent.right = v
 	}
 
-	p := node.Parent
-	for p != nil && !t.isNil(p) && node == p.Left {
-		node = p
-		p = p.Parent
-	}
-
-	if p == nil {
-		return t.NIL.Key, false
-	}
-	return p.Key, true
-}
-
-func (t *RB[T]) successorHelper(node *Node[T]) (T, bool) {
-	if !t.isNil(node.Right) {
-		return t.minimum(node.Right).Key, true
-	}
-
-	p := node.Parent
-	for p != nil && !t.isNil(p) && node == p.Right {
-		node = p
-		p = p.Parent
-	}
-
-	if p == nil {
-		return t.NIL.Key, false
-	}
-	return p.Key, true
+	v.parent = u.parent
 }

--- a/structure/tree/rbtree_test.go
+++ b/structure/tree/rbtree_test.go
@@ -26,13 +26,13 @@ func TestRBTreePush(t *testing.T) {
 		t.Errorf("Error with Max: %v", r)
 	}
 
-	nums := []int{10, 8, 88, 888, 4, 1<<63 - 1, -(1 << 62), 188, -188, 4, 88, 1 << 32}
+	nums := []int{10, 8, 88, 888, 4, 1<<63 - 1, -(1 << 62), 188, -188, 4, 1 << 32}
 
 	tree.Push(nums...)
 
 	ret = tree.InOrder()
 
-	if !sort.IntsAreSorted(ret) || len(ret) != len(nums) {
+	if !sort.IntsAreSorted(ret) {
 		t.Errorf("Error with Push: %v", ret)
 	}
 
@@ -54,27 +54,22 @@ func TestRBTreeDelete(t *testing.T) {
 
 	ok = tree.Delete(188)
 
-	if ret := tree.InOrder(); !ok || !sort.IntsAreSorted(ret) || len(ret) != len(nums)-1 {
+	if ret := tree.InOrder(); !ok || !sort.IntsAreSorted(ret) {
 		t.Errorf("Error with Delete: %v", ret)
 	}
 
 	ok = tree.Delete(188)
-	if ret := tree.InOrder(); ok || !sort.IntsAreSorted(ret) || len(ret) != len(nums)-1 {
+	if ret := tree.InOrder(); ok || !sort.IntsAreSorted(ret) {
 		t.Errorf("Error with Delete: %v", ret)
 	}
 
 	ok = tree.Delete(1<<63 - 1)
-	if ret := tree.InOrder(); !ok || !sort.IntsAreSorted(ret) || len(ret) != len(nums)-2 {
+	if ret := tree.InOrder(); !ok || !sort.IntsAreSorted(ret) {
 		t.Errorf("Error with Delete: %v", ret)
 	}
 
 	ok = tree.Delete(4)
-	if ret := tree.InOrder(); !ok || !sort.IntsAreSorted(ret) || len(ret) != len(nums)-3 {
-		t.Errorf("Error with Delete: %v", ret)
-	}
-
-	ok = tree.Delete(4)
-	if ret := tree.InOrder(); !ok || !sort.IntsAreSorted(ret) || len(ret) != len(nums)-4 {
+	if ret := tree.InOrder(); !ok || !sort.IntsAreSorted(ret) {
 		t.Errorf("Error with Delete: %v", ret)
 	}
 
@@ -87,16 +82,12 @@ func TestRBTreeDelete(t *testing.T) {
 	}
 }
 
-func FuzzRBTree(f *testing.F) {
+func TestRBTree(t *testing.T) {
 	testcases := []int{100, 200, 1000, 10000}
-	for _, tc := range testcases {
-		f.Add(tc)
-	}
-
-	f.Fuzz(func(t *testing.T, a int) {
+	for _, n := range testcases {
 		rand.Seed(time.Now().Unix())
 		tree := bt.NewRB[int]()
-		nums := rand.Perm(a)
+		nums := rand.Perm(n)
 		tree.Push(nums...)
 
 		rets := tree.InOrder()
@@ -108,68 +99,24 @@ func FuzzRBTree(f *testing.F) {
 			t.Errorf("Error with Min, get %d, want: %d", res, rets[0])
 		}
 
-		if res, ok := tree.Max(); !ok || res != rets[a-1] {
-			t.Errorf("Error with Max, get %d, want: %d", res, rets[a-1])
+		if res, ok := tree.Max(); !ok || res != rets[n-1] {
+			t.Errorf("Error with Max, get %d, want: %d", res, rets[n-1])
 		}
 
-		for i := 0; i < a-1; i++ {
+		for i := 0; i < n-1; i++ {
+			if ret, ok := tree.Successor(rets[0]); ret != rets[1] || !ok {
+				t.Error("Error with Successor")
+			}
+			if ret, ok := tree.Predecessor(rets[1]); ret != rets[0] || !ok {
+				t.Error("Error with Predecessor")
+			}
+
 			ok := tree.Delete(nums[i])
 			rets = tree.InOrder()
 			if !ok || !sort.IntsAreSorted(rets) {
 				t.Errorf("Error With Delete")
 			}
 		}
-	})
-}
-
-func TestRBTreePredecessorAndSuccessor(t *testing.T) {
-	tree := bt.NewRB[int]()
-
-	nums := []int{10, 8, 88, 888, 4, -1, 100}
-	tree.Push(nums...)
-
-	if ret, ok := tree.Predecessor(100); !ok && ret == 88 {
-		t.Errorf("Error with Predecessor")
-	}
-
-	if _, ok := tree.Predecessor(-1); ok {
-		t.Errorf("Error with Predecessor")
-	}
-
-	if _, ok := tree.Predecessor(-12); ok {
-		t.Errorf("Error with Predecessor")
-	}
-
-	if ret, ok := tree.Predecessor(4); !ok && ret == -1 {
-		t.Errorf("Error with Predecessor")
-	}
-
-	if ret, ok := tree.Successor(4); !ok && ret == 8 {
-		t.Errorf("Error with Successor")
-	}
-
-	if ret, ok := tree.Successor(8); !ok && ret == 88 {
-		t.Errorf("Error with Successor")
-	}
-
-	if ret, ok := tree.Successor(88); !ok && ret == 100 {
-		t.Errorf("Error with Successor")
-	}
-
-	if ret, ok := tree.Successor(100); !ok && ret == 888 {
-		t.Errorf("Error with Successor")
-	}
-
-	if ret, ok := tree.Successor(-1); !ok && ret == 4 {
-		t.Errorf("Error with Successor")
-	}
-
-	if _, ok := tree.Successor(888); ok {
-		t.Errorf("Error with Successor")
-	}
-
-	if _, ok := tree.Successor(188); ok {
-		t.Errorf("Error with Successor")
 	}
 }
 

--- a/structure/tree/tree_test.go
+++ b/structure/tree/tree_test.go
@@ -10,47 +10,42 @@ import (
 )
 
 func TestTreeGetOrHas(t *testing.T) {
+	helper := func(tree TestTree[int], nums []int) {
+		tree.Push(nums...)
+		for _, num := range nums {
+			if !tree.Has(num) {
+				t.Errorf("Error with Has or Push method")
+			}
+		}
+
+		min, _ := tree.Min()
+		max, _ := tree.Max()
+
+		if _, ok := tree.Get(min - 1); ok {
+			t.Errorf("Error with Get method")
+		}
+
+		if _, ok := tree.Get(max + 1); ok {
+			t.Errorf("Error with Get method")
+		}
+	}
+
 	lens := []int{100, 1_000, 10_000, 100_000}
 	for _, ll := range lens {
 		nums := rand.Perm(ll)
 		t.Run("Test Binary Search Tree", func(t *testing.T) {
 			bsTree := bt.NewBinarySearch[int]()
-			bsTree.Push(nums...)
-			for _, num := range nums {
-				if !bsTree.Has(num) {
-					t.Errorf("Error with Has or Push method")
-				}
-			}
-			min, _ := bsTree.Min()
-			max, _ := bsTree.Max()
-
-			if _, ok := bsTree.Get(min - 1); ok {
-				t.Errorf("Error with Get method")
-			}
-
-			if _, ok := bsTree.Get(max + 1); ok {
-				t.Errorf("Error with Get method")
-			}
+			helper(bsTree, nums)
 		})
 
 		t.Run("Test Red-Black Tree", func(t *testing.T) {
 			rbTree := bt.NewRB[int]()
-			rbTree.Push(nums...)
-			for _, num := range nums {
-				if !rbTree.Has(num) {
-					t.Errorf("Error with Has or Push method")
-				}
-			}
+			helper(rbTree, nums)
 		})
 
 		t.Run("Test AVL Tree", func(t *testing.T) {
 			avlTree := bt.NewAVL[int]()
-			avlTree.Push(nums...)
-			for _, num := range nums {
-				if !avlTree.Has(num) {
-					t.Errorf("Error with Has or Push method")
-				}
-			}
+			helper(avlTree, nums)
 		})
 	}
 }
@@ -261,43 +256,38 @@ func TestTreeLevelOrder(t *testing.T) {
 }
 
 func TestTreeMinAndMax(t *testing.T) {
+	helper := func(tree TestTree[int], nums []int) {
+		ll := len(nums)
+		if _, ok := tree.Min(); ok {
+			t.Errorf("Error with Min method.")
+		}
+		if _, ok := tree.Max(); ok {
+			t.Errorf("Error with Max method.")
+		}
+		tree.Push(nums...)
+		if min, ok := tree.Min(); !ok || min != nums[0] {
+			t.Errorf("Error with Min method.")
+		}
+		if max, ok := tree.Max(); !ok || max != nums[ll-1] {
+			t.Errorf("Error with Max method.")
+		}
+	}
+
 	lens := []int{500, 1_000, 10_000}
 	for _, ll := range lens {
 		nums := rand.Perm(ll)
 		sort.Ints(nums)
 
 		t.Run("Test Binary Search Tree", func(t *testing.T) {
-			bsTree := bt.NewBinarySearch[int]()
-			bsTree.Push(nums...)
-			if min, ok := bsTree.Min(); !ok || min != nums[0] {
-				t.Errorf("Error with Min method.")
-			}
-			if max, ok := bsTree.Max(); !ok || max != nums[ll-1] {
-				t.Errorf("Error with Max method.")
-			}
+			helper(bt.NewBinarySearch[int](), nums)
 		})
 
 		t.Run("Test Red-Black Tree", func(t *testing.T) {
-			rbTree := bt.NewRB[int]()
-			rbTree.Push(nums...)
-			if min, ok := rbTree.Min(); !ok || min != nums[0] {
-				t.Errorf("Error with Min method.")
-			}
-			if max, ok := rbTree.Max(); !ok || max != nums[ll-1] {
-				t.Errorf("Error with Max method.")
-			}
+			helper(bt.NewRB[int](), nums)
 		})
 
 		t.Run("Test AVL Tree", func(t *testing.T) {
-			avlTree := bt.NewAVL[int]()
-			avlTree.Push(nums...)
-			if min, ok := avlTree.Min(); !ok || min != nums[0] {
-				t.Errorf("Error with Min method.")
-			}
-
-			if max, ok := avlTree.Max(); !ok || max != nums[ll-1] {
-				t.Errorf("Error with Max method.")
-			}
+			helper(bt.NewAVL[int](), nums)
 		})
 	}
 }
@@ -357,62 +347,6 @@ func TestTreeDepth(t *testing.T) {
 			if ret := tree.Depth(); ret != tt.want {
 				t.Errorf("#%d Error with Depth", i)
 			}
-		}
-	})
-}
-
-func TestTreePrint(t *testing.T) {
-	t.Run("Test for Binary-Search Tree", func(t *testing.T) {
-		tests := []struct {
-			input []int
-			want  []int
-		}{
-			{[]int{90, 80, 100, 70, 85, 95, 105}, []int{70, 85, 80, 95, 105, 100, 90}},
-			{[]int{90, 80, 100, 70, 85, 95, 105, 1, 21, 31, 41, 51, 61, 71},
-				[]int{61, 51, 41, 31, 21, 1, 71, 70, 85, 80, 95, 105, 100, 90}},
-			{[]int{10, 9, 8, 7, 6, 5, 4, 3, 2, 1}, []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}},
-		}
-		for _, tt := range tests {
-			tree := bt.NewBinarySearch[int]()
-			t.Log(reflect.TypeOf(tree).String())
-			tree.Push(tt.input...)
-			tree.Print()
-		}
-	})
-
-	t.Run("Test for AVL Tree", func(t *testing.T) {
-		tests := []struct {
-			input []int
-			want  []int
-		}{
-			{[]int{90, 80, 100, 70, 85, 95, 105}, []int{70, 85, 80, 95, 105, 100, 90}},
-			{[]int{90, 80, 100, 70, 85, 95, 105, 1, 21, 31, 41, 51, 61, 71},
-				[]int{1, 31, 21, 61, 51, 41, 71, 85, 80, 95, 105, 100, 90, 70}},
-			{[]int{10, 9, 8, 7, 6, 5, 4, 3, 2, 1}, []int{1, 2, 4, 6, 5, 3, 8, 10, 9, 7}},
-		}
-		for _, tt := range tests {
-			tree := bt.NewAVL[int]()
-			t.Log(reflect.TypeOf(tree).String())
-			tree.Push(tt.input...)
-			tree.Print()
-		}
-	})
-
-	t.Run("Test for Red-Black Tree", func(t *testing.T) {
-		tests := []struct {
-			input []int
-			want  []int
-		}{
-			{[]int{90, 80, 100, 70, 85, 95, 105}, []int{70, 85, 80, 95, 105, 100, 90}},
-			{[]int{90, 80, 100, 70, 85, 95, 105, 1, 21, 31, 41, 51, 61, 71},
-				[]int{1, 31, 21, 51, 71, 70, 61, 41, 85, 95, 105, 100, 90, 80}},
-			{[]int{10, 9, 8, 7, 6, 5, 4, 3, 2, 1}, []int{1, 2, 4, 3, 6, 5, 8, 10, 9, 7}},
-		}
-		for _, tt := range tests {
-			tree := bt.NewRB[int]()
-			t.Log(reflect.TypeOf(tree).String() == "*tree.RB[int]")
-			tree.Push(tt.input...)
-			tree.Print()
 		}
 	})
 }
@@ -477,6 +411,81 @@ func TestTreeAccessNodesByLayer(t *testing.T) {
 				t.Errorf("#%d Error with AccessNoedsByLayer, %v", i, ret)
 			}
 		}
+	})
+}
+
+func TestTreePredecessorAndSuccessor(t *testing.T) {
+	helper := func(tree TestTree[int]) {
+		nums := []int{10, 8, 88, 888, 4, -1, 100}
+		tree.Push(nums...)
+		if ret, ok := tree.Predecessor(100); !ok || ret != 88 {
+			t.Error("Error with Predecessor")
+		}
+
+		if _, ok := tree.Predecessor(-1); ok {
+			t.Error("Error with Predecessor")
+		}
+
+		tree.Push(-100)
+		if ret, ok := tree.Predecessor(-1); !ok || ret != -100 {
+			t.Error("Error with Predecessor")
+		}
+
+		if _, ok := tree.Predecessor(-12); ok {
+			t.Error("Error with Predecessor")
+		}
+
+		if ret, ok := tree.Predecessor(4); !ok || ret != -1 {
+			t.Error("Error with Predecessor")
+		}
+
+		if ret, ok := tree.Successor(4); !ok || ret != 8 {
+			t.Error("Error with Successor")
+		}
+
+		if ret, ok := tree.Successor(8); !ok || ret != 10 {
+			t.Error("Error with Successor")
+		}
+
+		if ret, ok := tree.Successor(88); !ok || ret != 100 {
+			t.Error("Error with Successor")
+		}
+
+		if ret, ok := tree.Successor(100); !ok || ret != 888 {
+			t.Error("Error with Successor")
+		}
+
+		tree.Delete(888)
+		if _, ok := tree.Successor(100); ok {
+			t.Error("Error with Successor")
+		}
+
+		if ret, ok := tree.Successor(-1); !ok || ret != 4 {
+			t.Error("Error with Successor")
+		}
+
+		if _, ok := tree.Successor(888); ok {
+			t.Error("Error with Successor")
+		}
+
+		if _, ok := tree.Successor(188); ok {
+			t.Error("Error with Successor")
+		}
+	}
+
+	t.Run("Test for Binary Search Tree", func(t *testing.T) {
+		tree := bt.NewBinarySearch[int]()
+		helper(tree)
+	})
+
+	t.Run("Test for Red-Black Tree", func(t *testing.T) {
+		tree := bt.NewRB[int]()
+		helper(tree)
+	})
+
+	t.Run("Test for AVL Tree", func(t *testing.T) {
+		tree := bt.NewAVL[int]()
+		helper(tree)
 	})
 }
 


### PR DESCRIPTION
* add Parent to binary search tree

* refactor NIL in all trees

* add Successor and Predecessor to

* fix: tree package bug

* remove dummy variable leaf

* Refactoring: remove  method; make NIL a sentinel value for 3 trees, and eliminate nil in those implementations.

* change the method isRBTree to isRB

* fix:remove base struct, separate Node to three different nodes that complete Node Interface; still save NIL, but make it unexported

* Add more comments; Move Tree interface to tree_test package for future development.

* code tidy

* fix typo in comments